### PR TITLE
Consolidate documentation system and resolve Makefile target inconsistencies

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -50,8 +50,10 @@ jobs:
       - name: Build documentation
         working-directory: docs
         run: |
-          mkdocs build --strict
-          ls -la site/  # Verify build output exists
+          mike deploy --update-aliases latest
+          mike set-default latest
+          mike list
+          ls -la site/
 
       - name: Upload artifact
         uses: actions/upload-pages-artifact@v3

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -2,7 +2,7 @@ name: Deploy Documentation
 
 on:
   push:
-    branches: [main, ddd_refactor]
+    branches: [main]
     paths:
       - 'docs/**'
       - 'src/**'
@@ -12,6 +12,7 @@ on:
     paths:
       - 'docs/**'
       - 'src/**'
+  workflow_dispatch:
 
 permissions:
   contents: read
@@ -58,7 +59,7 @@ jobs:
           path: docs/site
 
   deploy:
-    if: github.ref == 'refs/heads/main' || github.ref == 'refs/heads/ddd_refactor'
+    if: github.ref == 'refs/heads/main'
     environment:
       name: github-pages
       url: ${{ steps.deployment.outputs.page_url }}

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -122,7 +122,7 @@ jobs:
     - name: Generate SBOM files
       run: |
         python -m pip install cyclonedx-bom
-        make ci-sbom
+        make ci-build-sbom
 
     - name: Upload SBOM artifacts
       uses: actions/upload-artifact@v4

--- a/Makefile
+++ b/Makefile
@@ -285,6 +285,21 @@ docs-build: dev-install  ## Build documentation
 	cd $(DOCS_DIR) && ../$(BIN)/mkdocs build
 	@echo "Documentation built in $(DOCS_BUILD_DIR)/"
 
+ci-docs: dev-install  ## Build documentation exactly like CI (matches docs.yml workflow)
+	@echo "Building documentation with CI settings..."
+	@echo "This matches the GitHub Actions docs.yml workflow exactly"
+	cd $(DOCS_DIR) && ../$(BIN)/mkdocs build --strict
+	@echo "Verifying build output exists..."
+	@ls -la $(DOCS_BUILD_DIR)/
+	@echo "Documentation built successfully in $(DOCS_BUILD_DIR)/"
+	@echo "To serve locally: python -m http.server 8000 --directory $(DOCS_BUILD_DIR)"
+
+ci-docs-serve: ci-docs  ## Build docs with CI settings and serve locally
+	@echo "Starting local server for CI-built documentation..."
+	@echo "Documentation available at: http://localhost:8000"
+	@echo "Press Ctrl+C to stop the server"
+	cd $(DOCS_BUILD_DIR) && python -m http.server 8000
+
 docs-serve-dev:  ## Serve documentation in development mode (non-versioned)
 	@echo "Starting development documentation server at http://127.0.0.1:8000"
 	@echo "Press Ctrl+C to stop the server"
@@ -339,9 +354,6 @@ docs-check-gitlab:  ## Check GitLab Pages deployment status
 	@echo "INFO: Staging URL:    https://aws-gfs-acceleration.gitlab.aws.dev/open-hostfactory-plugin/develop"
 	@echo "INFO: GitLab Project: https://gitlab.aws.dev/aws-gfs-acceleration/open-hostfactory-plugin"
 	@echo "INFO: CI/CD Pipelines: https://gitlab.aws.dev/aws-gfs-acceleration/open-hostfactory-plugin/-/pipelines"
-
-docs-clean:  ## Clean documentation build files
-	rm -rf $(DOCS_BUILD_DIR)
 
 # Version management targets
 version-bump-patch:  ## Bump patch version (0.1.0 -> 0.1.1)

--- a/Makefile
+++ b/Makefile
@@ -285,20 +285,14 @@ docs-build: dev-install  ## Build documentation
 	cd $(DOCS_DIR) && ../$(BIN)/mkdocs build
 	@echo "Documentation built in $(DOCS_BUILD_DIR)/"
 
-ci-docs: dev-install  ## Build documentation exactly like CI (matches docs.yml workflow)
+ci-docs-build: dev-install  ## Build documentation exactly like CI (matches docs.yml workflow)
 	@echo "Building documentation with CI settings..."
 	@echo "This matches the GitHub Actions docs.yml workflow exactly"
-	cd $(DOCS_DIR) && ../$(BIN)/mkdocs build --strict
+	cd $(DOCS_DIR) && ../$(BIN)/mike deploy --update-aliases latest
+	cd $(DOCS_DIR) && ../$(BIN)/mike set-default latest
 	@echo "Verifying build output exists..."
 	@ls -la $(DOCS_BUILD_DIR)/
 	@echo "Documentation built successfully in $(DOCS_BUILD_DIR)/"
-	@echo "To serve locally: python -m http.server 8000 --directory $(DOCS_BUILD_DIR)"
-
-ci-docs-serve: ci-docs  ## Build docs with CI settings and serve locally
-	@echo "Starting local server for CI-built documentation..."
-	@echo "Documentation available at: http://localhost:8000"
-	@echo "Press Ctrl+C to stop the server"
-	cd $(DOCS_BUILD_DIR) && python -m http.server 8000
 
 docs-serve-dev:  ## Serve documentation in development mode (non-versioned)
 	@echo "Starting development documentation server at http://127.0.0.1:8000"

--- a/Makefile
+++ b/Makefile
@@ -449,9 +449,10 @@ ci-security-hadolint: dev-install  ## Run Hadolint Dockerfile scan
 # Composite target
 ci-security: ci-security-bandit ci-security-safety  ## Run all security scans
 
-ci-imports: dev-install  ## Run import validation (matches CI import checks)
-	@echo "Running import validation..."
-	$(PYTHON) dev-tools/scripts/validate_imports.py
+ci-build-sbom: dev-install  ## Generate SBOM files (matches publish.yml workflow)
+	@echo "Generating SBOM files for CI..."
+	@echo "This matches the GitHub Actions publish.yml workflow exactly"
+	$(MAKE) sbom-generate
 
 ci-tests-unit: dev-install  ## Run unit tests only (matches ci.yml unit-tests job)
 	@echo "Running unit tests..."


### PR DESCRIPTION
## Description
This PR consolidates the documentation system to fix GitHub Pages deployment issues and establishes consistent naming patterns across all Makefile targets used in workflows.

**Primary Issues Resolved:**
- GitHub Pages was showing README instead of documentation due to inconsistent build systems
- Missing Makefile targets referenced in workflows (`ci-sbom`)
- Duplicate and confusing documentation build targets
- Inconsistent naming patterns across CI targets

**Key Changes:**
- Unified documentation system using mike for versioning in both local development and CI
- Removed duplicate documentation targets and established clear naming conventions
- Added missing targets and removed duplicates to ensure all workflow references work
- Simplified documentation deployment to only occur from main branch

## Type of Change
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] Documentation update
- [ ] Performance improvement
- [x] Code cleanup or refactor
- [ ] Dependencies update
- [x] CI/CD or build process changes

## Related Issues
Fixes GitHub Pages documentation deployment showing README instead of built documentation.
Resolves workflow failures due to missing Makefile targets.

## How Has This Been Tested?
- [x] Manual testing performed

**Testing Details:**
- Verified `make ci-docs-build` builds documentation with mike versioning
- Tested `make docs-serve` serves versioned documentation locally
- Confirmed `make ci-build-sbom` target exists and calls correct underlying target
- Validated all workflow-referenced targets exist in Makefile
- Verified documentation builds successfully with mike versioning system

## Test Configuration
* Python version: 3.13
* OS: macOS
* AWS region: us-east-1
* Dependencies changed: No new dependencies, existing mike/mkdocs usage consolidated

## Checklist
- [x] My code follows the project's style guidelines
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published
- [ ] I have updated the CHANGELOG.md file
- [ ] I have updated the version number (if applicable)

## Additional Notes

### Documentation System Changes
**Before:**
- CI used `mkdocs build --strict` (no versioning)
- Local development used `mike` (versioned)
- Multiple confusing targets: `ci-docs`, `ci-docs-mike`, `ci-docs-serve`
- GitHub Pages showed README instead of documentation

**After:**
- Both CI and local development use `mike` for consistent versioning
- Single clear target: `ci-docs-build` matches CI workflow exactly
- GitHub Pages will show properly versioned documentation
- Consistent experience between local development and deployed docs

### Makefile Target Consolidation
**Removed Duplicates:**
- `ci-docs`, `ci-docs-mike`, `ci-docs-serve` → consolidated to `ci-docs-build`
- `ci-imports` → use existing `ci-arch-imports` instead

**Added Missing:**
- `ci-build-sbom` → was referenced in `publish.yml` but didn't exist

**Consistent Naming Pattern:**
All CI targets now follow `ci-{category}-{action}` pattern:
- `ci-quality-{tool}` (black, mypy, etc.)
- `ci-arch-{check}` (cqrs, clean, imports, etc.)
- `ci-security-{tool}` (bandit, safety, etc.)
- `ci-tests-{type}` (unit, integration, e2e, etc.)
- `ci-docs-build`, `ci-build-sbom`

## Screenshots (if appropriate)
N/A - Infrastructure/build system changes

## Performance Impact
- [x] No significant performance impact
- [ ] Performance improved
- [ ] Performance degraded (explain why it's necessary)

Documentation builds now use mike consistently, which may be slightly slower than plain mkdocs but provides proper versioning functionality.

## Security Considerations
- [x] No security implications
- [ ] Security improved
- [ ] Potential security concerns (explain and justify)

## Dependencies
No new dependencies added. Existing mike and mkdocs dependencies are now used consistently across all documentation workflows.

## Migration Guide
No breaking changes for end users. Developers should use:
- `make ci-docs-build` to test documentation builds locally (matches CI exactly)
- `make docs-serve` to serve versioned documentation during development (unchanged)

## Deployment Notes
- GitHub Pages will now receive properly versioned documentation built with mike
- Documentation will only deploy from main branch (no longer from feature branches)
- All workflow targets now reference existing Makefile targets

## Reviewers
Please review the workflow changes and test the documentation build process locally using `make ci-docs-build` to ensure it matches the expected CI behavior.
