### PR TITLE
Correct license reference in documentation from MIT to Apache 2.0

### DIFF
--- a/docs/docs/index.md
+++ b/docs/docs/index.md
@@ -109,4 +109,4 @@ Direct installation on servers with systemd service configuration.
 
 ## License
 
-This project is licensed under the MIT License - see the LICENSE file for details.
+This project is licensed under the Apache License 2.0 - see the LICENSE file for details.


### PR DESCRIPTION
## Description
This PR corrects an inconsistency between the project's actual license (Apache 2.0) and the license reference in the documentation. The `docs/docs/index.md` file incorrectly stated the project was licensed under the MIT License, while the actual LICENSE file and pyproject.toml correctly specify Apache 2.0. This change updates the documentation to accurately reflect the project's actual license.

## Type of Change
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] Documentation update
- [ ] Performance improvement
- [ ] Code cleanup or refactor
- [ ] Dependencies update
- [ ] CI/CD or build process changes

## Related Issues
<!-- No specific issue number for this license correction -->

## How Has This Been Tested?
- [ ] Unit tests added/updated
- [ ] Integration tests added/updated
- [x] Manual testing performed
- [x] Verified documentation builds correctly with mkdocs
- [x] Confirmed no remaining MIT license references in project files
- [x] Validated consistency with LICENSE file and pyproject.toml

## Test Configuration
* Python version: 3.9+
* OS: macOS
* AWS region: N/A
* Dependencies changed: None

## Checklist
- [x] My code follows the project's style guidelines
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published
- [ ] I have updated the CHANGELOG.md file
- [ ] I have updated the version number (if applicable)

## Additional Notes
This is a simple documentation correction with no functional code changes. The fix ensures legal clarity and consistency across the project by aligning the documentation with the actual Apache 2.0 license specified in the LICENSE file.

## Screenshots (if appropriate)
N/A - Text-only documentation change

## Performance Impact
- [x] No significant performance impact
- [ ] Performance improved
- [ ] Performance degraded (explain why it's necessary)

## Security Considerations
- [x] No security implications
- [ ] Security improved
- [ ] Potential security concerns (explain and justify)

## Dependencies
None - no dependencies changed

## Migration Guide
N/A - no breaking changes

## Deployment Notes
No special deployment considerations - documentation change only

## Reviewers
<!-- @ mention specific team members who should review this -->
